### PR TITLE
Add new regex validator - `SigmahqUnsupportedRegexGroupConstruct`

### DIFF
--- a/sigma/validators/sigmahq/config.py
+++ b/sigma/validators/sigmahq/config.py
@@ -1603,6 +1603,7 @@ class ConfigHQ:
         "legitimeate",
         "legitimat",
     ]
+    sigmahq_unsupported_regex_group_constructs = ["(?=", "(?!", "(?<=", "(?<!", "(?>"]
     sigmahq_link_in_description = ["http://", "https://"]
     sigmahq_logsource_cast: Dict[SigmaLogSource, List[str]] = {}
     sigmahq_logsource_unicast: Dict[SigmaLogSource, List[str]] = {}

--- a/sigma/validators/sigmahq/detection.py
+++ b/sigma/validators/sigmahq/detection.py
@@ -99,7 +99,7 @@ class SigmahqUnsupportedRegexGroupConstructIssue(SigmaValidationIssue):
     unsupported_regexp: str
 
 
-class SigmahqUnsupportedRegexValidator(SigmaDetectionItemValidator):
+class SigmahqUnsupportedRegexGroupConstructValidator(SigmaDetectionItemValidator):
     """Checks if a rule uses a an unsupported regular expression group constructs."""
 
     def validate_detection_item(

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -6,12 +6,14 @@ from sigma.rule import SigmaRule
 from sigma.validators.sigmahq.detection import (
     SigmahqCategoryEventIdIssue,
     SigmahqCategoryEventIdValidator,
-    SigmahqCategoriProvidernameIssue,
-    SigmahqCategoriProvidernameValidator,
+    SigmahqCategoryWindowsProviderNameIssue,
+    SigmahqCategoryWindowsProviderNameValidator,
+    SigmahqUnsupportedRegexGroupConstructIssue,
+    SigmahqUnsupportedRegexGroupConstructValidator,
 )
 
 
-def test_validator_SigmahqCategorieEventid():
+def test_validator_SigmahqCategoryEventId():
     validator = SigmahqCategoryEventIdValidator()
     rule = SigmaRule.from_yaml(
         """
@@ -30,7 +32,7 @@ def test_validator_SigmahqCategorieEventid():
     assert validator.validate(rule) == [SigmahqCategoryEventIdIssue(rule)]
 
 
-def test_validator_SigmahqCategorieEventid_valid():
+def test_validator_SigmahqCategoryEventId_valid():
     validator = SigmahqCategoryEventIdValidator()
     rule = SigmaRule.from_yaml(
         """
@@ -48,8 +50,8 @@ def test_validator_SigmahqCategorieEventid_valid():
     assert validator.validate(rule) == []
 
 
-def test_validator_SigmahqCategoriProvidername():
-    validator = SigmahqCategoriProvidernameValidator()
+def test_validator_SigmahqCategoryWindowsProviderName():
+    validator = SigmahqCategoryWindowsProviderNameValidator()
     rule = SigmaRule.from_yaml(
         """
     title: A Space Field Name
@@ -64,11 +66,11 @@ def test_validator_SigmahqCategoriProvidername():
         condition: sel
     """
     )
-    assert validator.validate(rule) == [SigmahqCategoriProvidernameIssue(rule)]
+    assert validator.validate(rule) == [SigmahqCategoryWindowsProviderNameIssue(rule)]
 
 
-def test_validator_SigmahqCategoriProvidername_valid():
-    validator = SigmahqCategoriProvidernameValidator()
+def test_validator_SigmahqCategoryWindowsProviderName_valid():
+    validator = SigmahqCategoryWindowsProviderNameValidator()
     rule = SigmaRule.from_yaml(
         """
     title: A Space Field Name
@@ -79,6 +81,44 @@ def test_validator_SigmahqCategoriProvidername_valid():
     detection:
         sel:
             field: path\\*something
+        condition: sel
+    """
+    )
+    assert validator.validate(rule) == []
+
+
+def test_validator_SigmahqUnsupportedRegexGroupConstruct():
+    validator = SigmahqUnsupportedRegexGroupConstructValidator()
+    rule = SigmaRule.from_yaml(
+        """
+    title: A Space Field Name
+    status: test
+    logsource:
+        product: windows
+        category: process_creation
+    detection:
+        sel:
+            field|re: 'A(?=B)'
+        condition: sel
+    """
+    )
+    assert validator.validate(rule) == [
+        SigmahqUnsupportedRegexGroupConstructIssue([rule], "A(?=B)")
+    ]
+
+
+def test_validator_SigmahqUnsupportedRegexGroupConstruct_valid():
+    validator = SigmahqUnsupportedRegexGroupConstructValidator()
+    rule = SigmaRule.from_yaml(
+        """
+    title: A Space Field Name
+    status: test
+    logsource:
+        product: windows
+        category: process_creation
+    detection:
+        sel:
+            field|re: 'a\w+b'
         condition: sel
     """
     )

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -118,7 +118,7 @@ def test_validator_SigmahqUnsupportedRegexGroupConstruct_valid():
         category: process_creation
     detection:
         sel:
-            field|re: 'a\w+b'
+            field|re: "a\w+b"
         condition: sel
     """
     )

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -118,7 +118,7 @@ def test_validator_SigmahqUnsupportedRegexGroupConstruct_valid():
         category: process_creation
     detection:
         sel:
-            field|re: "a\w+b"
+            field|re: 'a\w+b'
         condition: sel
     """
     )


### PR DESCRIPTION
This PR adds `SigmahqUnsupportedRegexGroupConstruct` validator in order to check if a rule using the `re` modifier is using an unsupported group construct such as a `negative lookahead`. Such constructs are currently unsupported by multiple language such as rust and golang.