### PR TITLE
Updating config.py windows registry_event field to include 'ParentImage'

### DIFF
--- a/sigma/validators/sigmahq/config.py
+++ b/sigma/validators/sigmahq/config.py
@@ -1443,6 +1443,7 @@ Data_SigmaHQ_field_cast = {
             "Details",
             "EventType",
             "Image",
+            "ParentImage",
             "NewName",
             "ProcessGuid",
             "ProcessId",


### PR DESCRIPTION
**Change**
Added the field 'ParentImage' to windows registry_event.

This field can be useful in certain scenarios such as in this existing rule: https://github.com/SigmaHQ/sigma/blob/master/rules/windows/registry/registry_event/registry_event_susp_atbroker_change.yml

**Reason**
Using that field in new Sigma rules causes it to fail the Validation test with the Issue=SigmahqInvalidFieldnameIssue