### PR TITLE
Regression Updates

### DIFF
--- a/sigma/validators/sigmahq/metadata.py
+++ b/sigma/validators/sigmahq/metadata.py
@@ -237,7 +237,9 @@ class SigmahqUnknownFieldValidator(SigmaRuleValidator):
 
     def validate(self, rule: SigmaRuleBase) -> List[SigmaValidationIssue]:
         if len(rule.custom_attributes) > 0:
-            return [SigmahqUnknownFieldIssue([rule], list(rule.custom_attributes.keys()))]
+            custom_keys = list(rule.custom_attributes.keys())
+            if "regression_tests_path" not in custom_keys or "simulation" not in custom_keys:
+                return [SigmahqUnknownFieldIssue([rule], custom_keys)]
         else:
             return []
 
@@ -278,7 +280,9 @@ class SigmahqStatusToHighValidator(SigmaRuleValidator):
         if rule.date is not None and rule.status is not None:
             if rule.status > SigmaStatus.EXPERIMENTAL:
                 if (datetime.now().date() - rule.date).days <= self.min_days:
-                    return [SigmahqStatusToHighIssue([rule])]
+                    custom_keys = list(rule.custom_attributes.keys())
+                    if "regression_tests_path" not in custom_keys:
+                        return [SigmahqStatusToHighIssue([rule])]
         return []
 
 

--- a/sigma/validators/sigmahq/tags.py
+++ b/sigma/validators/sigmahq/tags.py
@@ -101,7 +101,7 @@ class SigmahqTagsTechniquesWithoutTacticsIssue(SigmaValidationIssue):
     description: ClassVar[str] = (
         "A MITRE ATT&CK technique tag was found without its corresponding tactic name. (e.g. when using 'attack.t1059' you have to add 'attack.execution' as well)"
     )
-    severity: ClassVar[SigmaValidationIssueSeverity] = SigmaValidationIssueSeverity.HIGH
+    severity: ClassVar[SigmaValidationIssueSeverity] = SigmaValidationIssueSeverity.MEDIUM
     techniques: List[str]
     missing_tactic: str
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -616,6 +616,27 @@ def test_validator_SigmahqStatusToHigh_valid():
     assert validator.validate(rule) == []
 
 
+def test_validator_SigmahqStatusToHigh_with_regression_valid():
+    validator = SigmahqStatusToHighValidator()
+    rule = SigmaRule.from_yaml(
+        """
+    title: Test
+    description: Test
+    status: test
+    date: 1975-01-01
+    logsource:
+        category: test
+    detection:
+        sel:
+            candle|exists: true
+        condition: sel
+    regression_tests_path: regression/rule/test_rule.yml
+    """
+    )
+    rule.date = datetime.now().date()
+    assert validator.validate(rule) == []
+
+
 def test_validator_SigmahqGithubLink():
     validator = SigmahqGithubLinkValidator()
     rule = SigmaRule.from_yaml(


### PR DESCRIPTION
This PR is updating some validator in preparation for the regression test added in https://github.com/SigmaHQ/sigma/pull/5719

- The `SigmahqStatusToHighValidator` test prevented rules from having a rule above `experimental` if they were less than 60 days old. This is rule can be bypassed for rule who provide test data, as these rules will start with a `test` status.
- The `SigmahqUnknownFieldValidator` prevented us from having custom fields not defined in the base class. Since we might not want to define those in the sigma base class (for now). I made the test bypass the condition for the new defined fields (keep in mind that the name is a work in progress and will only be final later on).
- I reduced the severity of the missing MITRE tactics test to `medium` as discussed internally.