### PR TITLE
Remove Local Dep for Taxonomy

### DIFF
--- a/sigma/validators/sigmahq/config.py
+++ b/sigma/validators/sigmahq/config.py
@@ -85,8 +85,8 @@ class ConfigHQ:
                 response = requests.get(url, timeout=10)
                 response.raise_for_status()
                 return response.json()
-            except Exception:
-                pass
+            except Exception as e:
+                print(f"Error loading remote {filename}: {e}")
             return None
         elif self.config_dir:
             path = self.config_dir / filename


### PR DESCRIPTION
This PR introduces a `DEFAULT_REMOTE_URL` variable that points to the folder where the taxonomy is stored.
With this we avoid the need to do a release everytime the taxonomy is updated and risk the `SigmahqInvalidFieldnameIssue` check failing upstream 